### PR TITLE
Add dashboard

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,6 @@ gem 'puma', '~> 3.12'
 gem 'rack-cors'
 gem 'rails', '~> 5.2.4'
 gem 'sass-rails', '~> 5.0'
-gem 'turbolinks', '~> 5'
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 gem 'uglifier', '>= 1.3.0'
 gem 'webpush'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -173,9 +173,6 @@ GEM
     thor (1.0.1)
     thread_safe (0.3.6)
     tilt (2.0.10)
-    turbolinks (5.2.1)
-      turbolinks-source (~> 5.2)
-    turbolinks-source (5.2.0)
     tzinfo (1.2.6)
       thread_safe (~> 0.1)
     uglifier (4.2.0)
@@ -215,7 +212,6 @@ DEPENDENCIES
   selenium-webdriver
   spring
   spring-watcher-listen (~> 2.0.0)
-  turbolinks (~> 5)
   tzinfo-data
   uglifier (>= 1.3.0)
   web-console (>= 3.3.0)
@@ -225,4 +221,4 @@ RUBY VERSION
    ruby 2.5.3p105
 
 BUNDLED WITH
-   1.17.2
+   1.17.3

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -12,5 +12,4 @@
 //
 //= require rails-ujs
 //= require activestorage
-//= require turbolinks
 //= require_tree .

--- a/app/assets/javascripts/main.js.erb
+++ b/app/assets/javascripts/main.js.erb
@@ -1,51 +1,108 @@
 window.addEventListener('load', () => {
-  if (!('serviceWorker' in navigator)) return console.log('serviceWorker not supported');
-  if (!('PushManager' in window)) return console.log('PushManager not supported');
+  if (!('serviceWorker' in navigator)) return console.log('service_worker: not_supported');
+  if (!('PushManager' in window)) return console.log('subscription: not_supported');
 
-  askPermission();
-  registerServiceWorker((push_subscription) => {
-    console.log('PushSubscription created.');
+  let enableNotificationsButton = document.getElementById('enable-notifications');
 
-    const payload = {
-      subscription: push_subscription,
-      max_actions: Notification.maxActions,
-    };
-
-    // send to API for storage
-    fetch('/push_subscriptions', {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json'
-      },
-      body: JSON.stringify(payload),
-    })
-    .then((response) => {
-      if (response.ok)
-        console.log('PushSubscription stored.');
-      else
-        console.log('PushSubscription not stored.');
-    })
-    .catch(error => console.error(error));
-  });
+  if (enableNotificationsButton) {
+    enableNotificationsButton.addEventListener('click', ()  => {
+      askPermission(() => {
+        registerServiceWorker((registration) => {
+          createSubscription(registration, (subscription) => {
+            persistSubscription(subscription);
+          });
+        });
+      });
+    });
+  }
 });
 
-function askPermission() {
+function askPermission(callback) {
   return new Promise((resolve, reject) => {
     const permission_result = Notification.requestPermission(result => resolve(result));
 
-    console.log('Max actions: ', Notification.maxActions);
+    console.log('notification/actions: ', Notification.maxActions);
 
     if (permission_result) permission_result.then(resolve, reject);
   })
   .then((permission_result) => {
-    if (permission_result === 'granted')
-      console.log('Permission granted.');
-    else
-      console.error('Permission not granted.');
+    if (permission_result === 'granted') {
+      console.log('notification: granted');
+
+      callback();
+    }
+    else {
+      console.error('notification: not_granted');
+    }
   })
   .catch((error) => {
     console.error(error);
   });
+}
+
+function createSubscription(registration, callback) {
+  let service_worker = getServiceWorker(registration);
+
+  const subscribeOptions = {
+    userVisibleOnly: true,
+    applicationServerKey: urlBase64ToUint8Array(
+      window.vapid_public_key
+    ),
+  };
+
+  if (service_worker) {
+    console.log('service_worker:', service_worker.state);
+
+    // if it's already activated when we get here, go ahead and create the subscription
+    if (service_worker.state == 'activated') {
+      registration.pushManager.subscribe(subscribeOptions).then((push_subscription) => {
+        console.log('subscription: created');
+
+        callback(push_subscription);
+      });
+    }
+
+    // add statechange listener
+    service_worker.addEventListener('statechange', (e) => {
+      console.log('service_worker:', e.target.state);
+
+      // if we get an activated state, the subscription still needs created
+      if (e.target.state == 'activated') {
+        registration.pushManager.subscribe(subscribeOptions).then((push_subscription) => {
+          console.log('subscription: created');
+
+          callback(push_subscription);
+        });
+      }
+    });
+  }
+}
+
+function getServiceWorker(registration) {
+  return registration.installing || registration.waiting || registration.active;
+}
+
+function persistSubscription(subscription) {
+  const payload = {
+    subscription: subscription,
+    max_actions: Notification.maxActions,
+  };
+
+  // send to API for storage
+  fetch('/push_subscriptions', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify(payload),
+  })
+  .then((response) => {
+    if (response.ok)
+      console.log('subscription: persisted');
+    else
+      console.log('subscription: not_persisted');
+  })
+  .catch(error => console.error(error));
 }
 
 function registerServiceWorker(callback) {
@@ -55,45 +112,11 @@ function registerServiceWorker(callback) {
     .then((registration) => {
       console.log('service_worker: registered');
 
-      let service_worker = getServiceWorker(registration);
-
-      const subscribeOptions = {
-        userVisibleOnly: true,
-        applicationServerKey: urlBase64ToUint8Array(
-          window.vapid_public_key
-        ),
-      };
-
-      if (service_worker) {
-        console.log('service_worker:', service_worker.state);
-
-        // if it's already activated when we get here, go ahead and create the subscription
-        if (service_worker.state == 'activated') {
-          registration.pushManager.subscribe(subscribeOptions).then((push_subscription) => {
-            callback(push_subscription);
-          });
-        }
-
-        // add statechange listener
-        service_worker.addEventListener('statechange', (e) => {
-          console.log('service_worker:', e.target.state);
-
-          // if we get an activated state, the subscription still needs created
-          if (e.target.state == 'activated') {
-            registration.pushManager.subscribe(subscribeOptions).then((push_subscription) => {
-              callback(push_subscription);
-            });
-          }
-        });
-      }
+      callback(registration);
     })
     .catch((error) => {
       console.error(error);
     });
-}
-
-function getServiceWorker(registration) {
-  return registration.installing || registration.waiting || registration.active;
 }
 
 // from https://github.com/GoogleChromeLabs/web-push-codelab/blob/master/app/scripts/main.js

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -1,0 +1,4 @@
+class DashboardController < ApplicationController
+  def index
+  end
+end

--- a/app/controllers/notifications/history_controller.rb
+++ b/app/controllers/notifications/history_controller.rb
@@ -1,8 +1,5 @@
 module Notifications
   class HistoryController < ApplicationController
-    skip_before_action :authenticate_by_session
-    before_action :authenticate_by_subscription
-
     helper_method :notification_responses
 
     def index
@@ -10,33 +7,11 @@ module Notifications
 
     private
 
-    def authenticate_by_subscription
-      @subscription = PushSubscription.find_by!(id: session[:push_subscription_id])
-    rescue ActiveRecord::RecordNotFound => _e
-      head :forbidden
-    end
-
-    def current_user_notifications
-      return unless current_user.persisted?
-
-      current_user.notifications.presence
-    end
-
     def notification_responses
       NotificationResponse
-        .where(notification: notifications)
+        .where(notification: current_user.notifications)
         .where(created_at: 2.weeks.ago..Time.current)
         .order(created_at: :asc)
-    end
-
-    def notifications
-      current_user_notifications || subscription_notifications || []
-    end
-
-    def subscription_notifications
-      return unless subscription.persisted?
-
-      subscription.notifications.presence
     end
   end
 end

--- a/app/controllers/welcome_controller.rb
+++ b/app/controllers/welcome_controller.rb
@@ -2,7 +2,7 @@ class WelcomeController < ApplicationController
   skip_before_action :authenticate_by_session
 
   def index
-    redirect_to history_index_path if current_user.persisted?
+    redirect_to dashboard_index_path if current_user.persisted?
   end
 
   def sign_up

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -1,0 +1,9 @@
+<h2>Mood</h2>
+
+<p>View your mood entries for the past 2 weeks.</p>
+
+<p><a class="btn btn-primary" href="<%= history_index_path %>">View Entries</a></p>
+
+<p>Enable push notifications on this device (the browser will prompt you). This device will be linked to your account.</p>
+
+<p><button id="enable-notifications" class="btn btn-primary">Enable Notifications</button></p>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -12,8 +12,8 @@
     </script>
 
     <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/css/bootstrap.min.css" integrity="sha384-Vkoo8x4CGsO3+Hhxv8T/Q5PaXtkKtu6ug5TOeNV6gBiFeWPGFN9MuhOf23Q9Ifjh" crossorigin="anonymous">
-    <%= stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload' %>
-    <%= javascript_include_tag 'application', 'data-turbolinks-track': 'reload' %>
+    <%= stylesheet_link_tag 'application', media: 'all' %>
+    <%= javascript_include_tag 'application' %>
   </head>
 
   <body>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,8 @@ Rails.application.routes.draw do
 
   get :sign_up, to: 'welcome#sign_up'
 
+  resources :dashboard, only: [:index]
+
   resources :ephemeral, only: [] do
     collection do
       get :authenticate_by_notification


### PR DESCRIPTION
- only request permission to send notifications after user opts in (button click)
  - required by firefox -- other browsers will also require this soon
- redirect users to dashboard instead of history page after logging in
- change history page to only support user session auth
  - todo: change notification auth to single route with redirect (create session from nonce)
- remove turbolinks